### PR TITLE
Add books to the DB from /admin

### DIFF
--- a/lib/library/application.ex
+++ b/lib/library/application.ex
@@ -6,7 +6,7 @@ defmodule Library.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
-    unless Mix.env == :prod do
+    unless Mix.env == :prod || Mix.env == :test do
       Envy.load(["config.env"])
       Envy.reload_config()
     end

--- a/lib/library/google_books/google_books.ex
+++ b/lib/library/google_books/google_books.ex
@@ -1,5 +1,4 @@
 defmodule Library.GoogleBooks do
-  @book_api_url "https://www.googleapis.com/books/v1/volumes?key=#{System.get_env "GOOGLE_BOOKS_KEY"}&q="
   @desired_info ["title", "authors", "publishedDate", "printType", "categories", ["imageLinks", "thumbnail"], ["imageLinks", "smallThumbnail"], "language", "previewLink", "industryIdentifiers"]
   @keys_to_rename [{"title", :title}, {"authors", :author_list},
                    {"publishedDate", :date_published}, {"printType", :type},
@@ -37,7 +36,8 @@ defmodule Library.GoogleBooks do
   def handle_api_decode(result) do
     case result do
       {:ok, map} ->
-        Map.get(map, "items")
+        map
+        |> Map.get("items")
         |> Enum.reduce([], fn (%{"volumeInfo" => map}, acc) ->
           map
           |> get_values_from_map(@desired_info)
@@ -73,8 +73,11 @@ defmodule Library.GoogleBooks do
   defp get_isbns(map), do: map
 
   def create_url(search_query, search_category) do
+    key = System.get_env "GOOGLE_BOOKS_KEY"
+    url = "https://www.googleapis.com/books/v1/volumes?key=#{key}&q="
+
     query = URI.encode(search_query)
-    @book_api_url <> case search_category do
+    url <> case search_category do
       "title" ->
         "intitle:" <> query
       "isbn" ->

--- a/lib/library_web/controllers/admin_controller.ex
+++ b/lib/library_web/controllers/admin_controller.ex
@@ -12,4 +12,20 @@ defmodule LibraryWeb.AdminController do
 
     render(conn, "index.html", books: books)
   end
+
+  def create(conn, %{"author_list" => authors} = params) do
+      params
+      |> Map.put("author_list", String.split(authors, ";"))
+      |> Library.Books.create_book_authors!
+      |> case do
+        false ->
+          conn
+          |> put_flash(:info, "Book not added, already in library")
+        _ ->
+          conn
+          |> put_flash(:info, "Book added")
+      end
+      |> render("index.html", books: [])
+
+  end
 end

--- a/lib/library_web/router.ex
+++ b/lib/library_web/router.ex
@@ -24,7 +24,7 @@ defmodule LibraryWeb.Router do
 
     get "/", AdminController, :index
     get "/search", AdminController, :search
-    get "/create", AdminController, :create
+    post "/create", AdminController, :create
   end
 
   # Other scopes may use custom stacks.

--- a/lib/library_web/templates/admin/index.html.eex
+++ b/lib/library_web/templates/admin/index.html.eex
@@ -6,7 +6,7 @@
   </div>
   <div class="w-100 ph3">
     <%= form_for @conn, admin_path(@conn, :search), [as: :search, method: :get, enforce_utf8: false], fn f -> %>
-      <%= text_input f, :query, class: "w-100 focus-light-grey dark-grey pv2 ph2 bg-light-grey input-reset ba b--black-20 mb3 bs-bb", placeholder: "progamming phoenix"%>
+      <%= text_input f, :query, class: "w-100 focus-light-grey dark-grey pv2 ph2 bg-light-grey input-reset ba b--black-20 mb3 bs-bb", placeholder: "programming phoenix"%>
     <% end %>
   </div>
 </div>

--- a/lib/library_web/templates/component/book.html.eex
+++ b/lib/library_web/templates/component/book.html.eex
@@ -9,12 +9,7 @@
     </span>
   </h2>
   <div class="ml3 w4 mw3-5 pt1">
-    <%= query = assigns.book
-          |> Map.put(:author_list, Enum.join(assigns.book.author_list, ";"))
-          |> Map.delete(:category)
-          |> URI.encode_query()
-        path = page_path(assigns.conn, :index) <> "?" <> query
-        link("Add book", to: path <> "?" <> query, class: "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-teal") %>
+    <%= link("Add book", to: admin_path(assigns.conn, :create) <> "?" <> create_query_string(assigns.book), class: "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-teal", method: :post)%>
     <%= link("More info", to: page_path(assigns.conn, :index), class: "f6 w-100 tc ba link dim pv1 mb2 dib dwyl-teal") %>
   </div>
 </div>

--- a/lib/library_web/templates/component/book.html.eex
+++ b/lib/library_web/templates/component/book.html.eex
@@ -1,6 +1,6 @@
 <div class="w-100 db v-top mb2 pa3 bs-bb bg-white link dark-grey flex">
   <div class="w-100 w-image mr3">
-    <%= img_tag(Map.get(assigns.book, :thumbnail_small) || static_path(@conn, "/images/null-image.png"), alt: "#{assigns.book.title} cover image", class: "mt1 h-100 h-image shadow-4") %>
+    <%= img_tag(get_thumbnail(assigns.book, @conn), alt: "#{assigns.book.title} cover image", class: "mt1 h-100 h-image shadow-4") %>
   </div>
   <h2 class="f6 dib v-top ma0 fg1 lh-copy">
     <%= assigns.book.title %><br/>

--- a/lib/library_web/views/component_view.ex
+++ b/lib/library_web/views/component_view.ex
@@ -7,5 +7,8 @@ defmodule LibraryWeb.ComponentView do
     |> Map.delete(:category)
     |> URI.encode_query()
   end
-  
+
+  def get_thumbnail(book, conn) do
+    Map.get(book, :thumbnail_small) || static_path(conn, "/images/null-image.png")
+  end
 end

--- a/lib/library_web/views/component_view.ex
+++ b/lib/library_web/views/component_view.ex
@@ -1,3 +1,11 @@
 defmodule LibraryWeb.ComponentView do
   use LibraryWeb, :view
+
+  def create_query_string(book) do
+    book
+    |> Map.put(:author_list, Enum.join(book.author_list, ";"))
+    |> Map.delete(:category)
+    |> URI.encode_query()
+  end
+  
 end

--- a/test/library/books/books_test.exs
+++ b/test/library/books/books_test.exs
@@ -159,7 +159,7 @@ defmodule Library.BooksTest do
     Books.create_book_authors!(%{title: "another book",
                                 author_list: ["some author"]})
 
-    book_one = Books.get_book_by_title("some book")
+    book_one = Books.get_book_by_title!("some book")
 
     assert Enum.count(Books.list_authors) == 2
     assert Enum.count(Books.list_books) == 2

--- a/test/library_web/controllers/admin_controller_test.exs
+++ b/test/library_web/controllers/admin_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule LibraryWeb.AdminControllerTest do
   use LibraryWeb.ConnCase
+  alias Library.Books
 
   @books %{books: [%{title: "Test title", author_list: ["Test author"],
                      thumbnail_small: "test.jpg", owned: false}]}
@@ -14,6 +15,25 @@ defmodule LibraryWeb.AdminControllerTest do
   test "GET /search", %{conn: conn} do
     conn = conn
     |> get("/admin/search", %{"search" => %{"query" => "harry potter"}})
+    assert html_response(conn, 200) =~ "dwyl | Library"
+  end
+
+  test "post /create with a book that already exists in db", %{conn: conn} do
+    book = %{"title" => "harry potter", "author_list" => "jk rowling", "owned" => false}
+
+    book
+    |> Map.put("author_list", [book["author_list"]])
+    |> Books.create_book_authors!
+
+    conn = conn
+    |> post("/admin/create", book)
+    assert html_response(conn, 200) =~ "dwyl | Library"
+  end
+
+  test "post /create", %{conn: conn} do
+    book = %{"title" => "harry potter", "author_list" => "jk rowling", "owned" => false}
+    conn = conn
+    |> post("/admin/create", book)
     assert html_response(conn, 200) =~ "dwyl | Library"
   end
 end


### PR DESCRIPTION
Allows books to be created through the /admin route #13 . This includes:
- Dynamic links for each book that contain all the information needed to add a book
- Stops `create_book_authors!` from adding the same book more than once
- Adds a `:create` route that adds authors to the database
- Also addresses the code quality issues raised in the last PR #15 
- And adds a temporary fix for #20 