### PR TITLE
Replace web results with database version

### DIFF
--- a/lib/library/books/books.ex
+++ b/lib/library/books/books.ex
@@ -45,7 +45,23 @@ defmodule Library.Books do
     Repo.all(query)
   end
 
+  @doc """
+  Replaces non-database books with the database version if it exists.
 
+  Takes a list of books and returns a list of books with updated entries.
+  """
+  def replace_matches_with_db(books) do
+    Enum.map(books, fn book ->
+      query = from b in Book,
+              where: b.title == ^book.title,
+              where: b.author_list == ^book.author_list
+
+      case Repo.all(query) do
+        [db_book] -> db_book
+        [] -> book
+      end
+    end)
+  end
 
   @doc """
   Gets a single book.

--- a/lib/library_web/controllers/page_controller.ex
+++ b/lib/library_web/controllers/page_controller.ex
@@ -11,6 +11,7 @@ defmodule LibraryWeb.PageController do
 
   def search(conn, %{"search" => %{"author" => _author, "isbn" => _isbn, "title" => title}, "web" => _web}) do
     books = GoogleBooks.google_books_search(title, "title")
+    |> replace_matches_with_db()
 
     render(conn, "index.html", books: books, web: "web")
   end

--- a/lib/library_web/templates/component/book.html.eex
+++ b/lib/library_web/templates/component/book.html.eex
@@ -7,6 +7,12 @@
     <span class="f6 v-top medium-grey ma0 fw3">
       <%= Enum.join assigns.book.author_list, ", " %>
     </span>
+    <%= if !Map.get(assigns.book, :web) && Map.get(@conn.assigns, :web) do %>
+      <br/>
+      <span class="dwyl-teal fw3">
+        In the library
+      </span>
+    <% end %>
   </h2>
   <div class="ml3 w4 mw3-5 pt1">
     <%= link(get_button_text(assigns.book, assigns.conn), get_button_options(assigns.book, assigns.conn)) %>

--- a/test/library/books/books_test.exs
+++ b/test/library/books/books_test.exs
@@ -76,6 +76,18 @@ defmodule Library.BooksTest do
       assert Enum.count(Books.search_books("", "123", "")) == 1
     end
 
+    test "replace_matches_with_db/1 replaces any matched books with the database equivalent" do
+      book_authors_fixture(%{title: "some book", author_list: ["some author"], isbn_13: "123"})
+      db_book = Books.get_book_by_title!("some book")
+
+      book_1 = %{title: "incorrect book", author_list: ["incorrect author"]}
+      book_2 = %{title: "some book", author_list: ["some author"]}
+
+      books = [book_1, book_2]
+
+      assert Books.replace_matches_with_db(books) == [book_1, db_book]
+    end
+
     test "get_book!/1 returns the book with given id" do
       book = book_fixture()
       fetched_book = Books.get_book!(book.id)


### PR DESCRIPTION
Runs through all web results to check for matches in the database. If there's a match, replace the entry. Also adds a label to the template #22