### PR TITLE
Reroutes all routes to path routes

### DIFF
--- a/lib/library/books/books.ex
+++ b/lib/library/books/books.ex
@@ -170,7 +170,7 @@ defmodule Library.Books do
     iex> get_book_by_title_and_authors("not a title")
     []
   """
-  def get_books_by_title_and_authors(%{"title" => title, "author_list" => author_list}), do: get_books_by_title_and_authors(title, author_list)
+
   def get_books_by_title_and_authors(%{title: title, author_list: author_list}), do: get_books_by_title_and_authors(title, author_list)
   def get_books_by_title_and_authors(title, author_list) do
     query = from b in "books",
@@ -227,18 +227,13 @@ defmodule Library.Books do
     does exactly the same as create_book_authors! but returns the book that was inserted, rather than {:ok, :ok}
   """
   def create_book_authors_return_book!(attrs \\ %{}) do
-    unless book_exists?(attrs) do
-      Repo.transaction fn ->
         book = create_book!(attrs)
+
         book
         |> Repo.preload(:author)
         |> create_authors_for_book!()
 
         book
-      end
-    else
-      false
-    end
   end
   @doc """
   Adds all the authors of a book to the authors table.

--- a/lib/library/books/books.ex
+++ b/lib/library/books/books.ex
@@ -215,11 +215,26 @@ defmodule Library.Books do
         |> Repo.preload(:author)
         |> create_authors_for_book!()
       end
+    end
+  end
+
+  @doc """
+    does exactly the same as create_book_authors! but returns the book that was inserted, rather than {:ok, :ok}
+  """
+  def create_book_authors_return_book!(attrs \\ %{}) do
+    unless book_exists?(attrs) do
+      Repo.transaction fn ->
+        book = create_book!(attrs)
+        book
+        |> Repo.preload(:author)
+        |> create_authors_for_book!()
+
+        book
+      end
     else
       false
     end
   end
-
   @doc """
   Adds all the authors of a book to the authors table.
 

--- a/lib/library_web/controllers/admin_controller.ex
+++ b/lib/library_web/controllers/admin_controller.ex
@@ -6,17 +6,14 @@ defmodule LibraryWeb.AdminController do
   plug LibraryWeb.Plugs.RequireAdmin
 
   def create(conn, %{"author_list" => authors} = params) do
-      params
+      book = params
       |> Map.put("author_list", String.split(authors, ";"))
       |> Map.put("owned", true)
       |> Library.Books.create_book_authors_return_book!
-      |> case do
-        {:ok, book} ->
-          conn
-          |> put_flash(:info, "Book added")
-          |> redirect(to: page_path(conn, :show, book.id))
-      end
 
+      conn
+      |> put_flash(:info, "Book added")
+      |> redirect(to: page_path(conn, :show, book.id))
   end
 
   def delete(conn, %{"id" => id}) do

--- a/lib/library_web/controllers/admin_controller.ex
+++ b/lib/library_web/controllers/admin_controller.ex
@@ -1,35 +1,21 @@
 defmodule LibraryWeb.AdminController do
   use LibraryWeb, :controller
 
-  alias Library.GoogleBooks
   alias Library.Books
 
   plug LibraryWeb.Plugs.RequireAdmin
-
-  def index(conn, _params) do
-    render(conn, "index.html", books: [])
-  end
-
-  def search(conn, %{"search" => %{"query" => query}}) do
-    books = GoogleBooks.google_books_search(query, "title")
-
-    render(conn, "index.html", books: books)
-  end
 
   def create(conn, %{"author_list" => authors} = params) do
       params
       |> Map.put("author_list", String.split(authors, ";"))
       |> Map.put("owned", true)
-      |> Library.Books.create_book_authors!
+      |> Library.Books.create_book_authors_return_book!
       |> case do
-        false ->
-          conn
-          |> put_flash(:info, "Book not added, already in library")
-        _ ->
+        {:ok, book} ->
           conn
           |> put_flash(:info, "Book added")
+          |> redirect(to: page_path(conn, :show, book.id))
       end
-      |> render("index.html", books: [])
 
   end
 
@@ -38,6 +24,6 @@ defmodule LibraryWeb.AdminController do
     Books.get_book!(id)
     |> Books.delete_book_and_unique_authors
 
-    render(conn, "index.html", books: [])
+    redirect(conn, to: page_path(conn, :index))
   end
 end

--- a/lib/library_web/controllers/login_controller.ex
+++ b/lib/library_web/controllers/login_controller.ex
@@ -5,13 +5,6 @@ defmodule LibraryWeb.LoginController do
 
   @httpoison Application.get_env(:library, :httpoison) || HTTPoison
 
-  @doc """
-    Just shows the user the plain index.html
-  """
-  def index(conn, _params) do
-    render conn, "index.html"
-  end
-
 
   @doc """
     Creates a github URL with the scope for getting the user's email and orgs
@@ -26,7 +19,7 @@ defmodule LibraryWeb.LoginController do
         # TODO: set internal server error
         conn
         |> put_flash(:error, "Something went wrong on our end, try again later!")
-        |> render("index.html")
+        |> redirect(to: page_path(conn, :index))
       {:ok, url} ->
         redirect conn, external: url
     end
@@ -48,7 +41,7 @@ defmodule LibraryWeb.LoginController do
       {:error, _error} ->
         conn
         |> put_flash(:error, "Problem getting info from github, try again later")
-        |> render("index.html")
+        |> redirect(to: page_path(conn, :index))
       {:ok, user} ->
         case add_user(user) do
             {:ok, user} ->
@@ -71,7 +64,7 @@ defmodule LibraryWeb.LoginController do
     |> delete_session(:user_id)
     |> redirect(to: page_path(conn, :index))
   end
-  
+
   defp add_user(%{"name" => first_name, "login" => username, "access_token" => token}) do
     case get_orgs_and_email(token) do
       {:ok, %{"orgs" => orgs, "email" => email}} ->

--- a/lib/library_web/router.ex
+++ b/lib/library_web/router.ex
@@ -27,8 +27,6 @@ defmodule LibraryWeb.Router do
   scope "/admin", LibraryWeb do
     pipe_through :browser
 
-    get "/", AdminController, :index
-    get "/search", AdminController, :search
     post "/create", AdminController, :create
     get "/delete/:id", AdminController, :delete
   end
@@ -36,7 +34,6 @@ defmodule LibraryWeb.Router do
   scope "/login", LibraryWeb do
     pipe_through :browser
 
-    get "/", LoginController, :index
     get "/github", LoginController, :login
     get "/github-callback", LoginController, :callback
     get "/logout", LoginController, :logout

--- a/lib/library_web/views/component_view.ex
+++ b/lib/library_web/views/component_view.ex
@@ -73,7 +73,7 @@ defmodule LibraryWeb.ComponentView do
 
   def get_button_options(book, conn) do
     active = "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-teal"
-    error = "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-red"
+    # error = "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-red"
     inactive = "f6 w-100 tc link pv1 mb2 dib moon-gray bg-light-grey"
 
     case get_button_text(book, conn) do

--- a/test/library_web/controllers/admin_controller_test.exs
+++ b/test/library_web/controllers/admin_controller_test.exs
@@ -5,9 +5,6 @@ defmodule LibraryWeb.AdminControllerTest do
   alias Library.Users.User
   alias Library.Users
 
-  @books %{books: [%{title: "Test title", author_list: ["Test author"],
-                     thumbnail_small: "test.jpg", owned: false}]}
-
   @admin %{
     email: "hello@dwyl.com",
     first_name: "dwyl",
@@ -16,57 +13,6 @@ defmodule LibraryWeb.AdminControllerTest do
     is_admin: true
   }
 
-  test "GET / with access", %{conn: conn} do
-    {:ok, %User{id: user_id}} = Users.create_user(@admin)
-
-    conn = conn
-    |> Map.put(:assigns, @books)
-    |> init_test_session(%{user_id: user_id})
-    |> get("/admin")
-    assert html_response(conn, 200) =~ "dwyl | Library"
-  end
-
-  test "GET / without access", %{conn: conn} do
-    conn = conn
-    |> Map.put(:assigns, @books)
-    |> get("/admin")
-    assert html_response(conn, 302) =~ "redirected"
-  end
-
-  test "GET /search with access", %{conn: conn} do
-
-    {:ok, %User{id: user_id}} = Users.create_user(@admin)
-
-    conn = conn
-    |> Map.put(:assigns, @books)
-    |> init_test_session(%{user_id: user_id})
-    |> get("/admin/search", %{"search" => %{"query" => "harry potter"}})
-
-    assert html_response(conn, 200) =~ "dwyl | Library"
-  end
-
-  test "GET /search without access", %{conn: conn} do
-    conn = conn
-    |> get("/admin/search", %{"search" => %{"query" => "harry potter"}})
-    assert html_response(conn, 302) =~ "redirected"
-  end
-
-  test "post /create with a book that already exists in db with access", %{conn: conn} do
-    book = %{"title" => "harry potter", "author_list" => "jk rowling", "owned" => false}
-
-    {:ok, %User{id: user_id}} = Users.create_user(@admin)
-
-    book
-    |> Map.put("author_list", [book["author_list"]])
-    |> Books.create_book_authors!
-
-    conn = conn
-    |> init_test_session(%{user_id: user_id})
-    |> Map.put(:assigns, @books)
-    |> post("/admin/create", book)
-    assert html_response(conn, 200) =~ "dwyl | Library"
-  end
-
   test "post /create with access", %{conn: conn} do
     book = %{"title" => "harry potter", "author_list" => "jk rowling", "owned" => false}
     {:ok, %User{id: user_id}} = Users.create_user(@admin)
@@ -74,7 +20,7 @@ defmodule LibraryWeb.AdminControllerTest do
     conn = conn
     |> init_test_session(%{user_id: user_id})
     |> post("/admin/create", book)
-    assert html_response(conn, 200) =~ "dwyl | Library"
+    assert html_response(conn, 302) =~ "redirected"
   end
 
   test "post /create without access", %{conn: conn} do
@@ -86,11 +32,14 @@ defmodule LibraryWeb.AdminControllerTest do
 
   test "GET /delete/ with access", %{conn: conn} do
     {:ok, %User{id: user_id}} = Users.create_user(@admin)
+
     Books.create_book_authors!(%{title: "some title", author_list: ["some author"]})
+
     [%{id: id} | _tail] = Books.list_books()
     conn = conn
     |> init_test_session(%{user_id: user_id})
     |> get("/admin/delete/#{id}")
-    assert html_response(conn, 200) =~ "dwyl | Library"
+    assert html_response(conn, 302) =~ "redirected"
   end
+
 end

--- a/test/library_web/controllers/login_controller_test.exs
+++ b/test/library_web/controllers/login_controller_test.exs
@@ -2,11 +2,6 @@ defmodule LibraryWeb.LoginControllerTest do
   use LibraryWeb.ConnCase
   alias Library.Users
 
-  test "GET /", %{conn: conn} do
-    conn = get conn, "/login"
-    assert html_response(conn, 200) =~ "dwyl | Library"
-  end
-
   test "GET /login with env set", %{conn: conn} do
     Application.put_env(:elixir_auth_github, :client_id, "TEST_ID")
     conn = get conn, "/login/github"
@@ -17,12 +12,12 @@ defmodule LibraryWeb.LoginControllerTest do
   test "GET /login without env set", %{conn: conn} do
     Application.put_env(:elixir_auth_github, :client_id, nil)
     conn = get conn, "/login/github"
-    assert html_response(conn, 200) =~ "dwyl | Library"
+    assert html_response(conn, 302) =~ "redirected"
   end
 
   test "GET /login/github-callback with error on first gh call", %{conn: conn} do
     conn = get conn, "/login/github-callback", %{"code" => "123"}
-    assert html_response(conn, 200) =~ "Problem getting info from github, try again later"
+      assert html_response(conn, 302) =~ "redirected"
   end
 
   test "GET /login/github-callback with success", %{conn: conn} do


### PR DESCRIPTION
All routes in the `/admin` and `/login` scopes now redirect to pages in the `page` scope, so that we don't have any unnecessary repetition. 

#60 
