### PR TITLE
display 'on loan' instead of 'join queue'

### DIFF
--- a/lib/library_web/views/component_view.ex
+++ b/lib/library_web/views/component_view.ex
@@ -100,7 +100,7 @@ defmodule LibraryWeb.ComponentView do
       loan && user && (user.id == loan.user_id || admin) ->
         "Check in"
       loan ->
-        "Join queue"
+        "On loan"
       owned && admin ->
         "Remove"
       owned ->
@@ -118,6 +118,7 @@ defmodule LibraryWeb.ComponentView do
 
   def get_button_options(book, conn) do
     active = "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-teal"
+    error = "f6 w-100 tc link pv1 mb2 dib white bg-light-red"
     inactive = "f6 w-100 tc link pv1 mb2 dib moon-gray bg-light-grey"
 
     case get_button_text(book, conn) do
@@ -127,8 +128,8 @@ defmodule LibraryWeb.ComponentView do
         [to: admin_path(conn, :create) <> "?" <> create_query_string(book),
         class: active,
         method: :post]
-      "Join queue" ->
-        [to: "#", class: inactive]
+      "On loan" ->
+        [to: "#", class: error]
       "Check in" ->
         [to: page_path(conn, :checkin, Map.get(book, :id)), class: active]
       "Check out" ->

--- a/test/library_web/views/component_view_test.exs
+++ b/test/library_web/views/component_view_test.exs
@@ -55,10 +55,10 @@ defmodule LibraryWeb.ComponentViewTest do
       assert ComponentView.get_button_text(@on_loan_book, @second_user) != "Check in"
     end
 
-    test "get_button_text displays 'Join queue' for the correct values" do
-      assert ComponentView.get_button_text(@on_loan_book, @admin_user) != "Join queue"
-      assert ComponentView.get_button_text(@on_loan_book, @normal_user) != "Join queue"
-      assert ComponentView.get_button_text(@on_loan_book, @second_user) == "Join queue"
+    test "get_button_text displays 'On loan' for the correct values" do
+      assert ComponentView.get_button_text(@on_loan_book, @admin_user) != "On loan"
+      assert ComponentView.get_button_text(@on_loan_book, @normal_user) != "On loan"
+      assert ComponentView.get_button_text(@on_loan_book, @second_user) == "On loan"
     end
 
     test "get_button_text displays 'Check out' for the correct values" do
@@ -105,7 +105,7 @@ defmodule LibraryWeb.ComponentViewTest do
         [to: "/admin/delete/1",
          class: "f6 w-100 tc link dim pv1 mb2 dib white bg-dwyl-teal"]
     end
-    
+
     test "test loan_html for books loaned to you", %{conn: conn} do
       user_conn = Map.merge(conn, @normal_user)
       assert ComponentView.loan_html(@on_loan_book_user, user_conn) ==


### PR DESCRIPTION
Until we get #28 merged in it shouldn't say 'join queue'

#27 