### PR TITLE
adds auth requirement to checkout/checkin route

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -15,7 +15,6 @@
     "lib/library_web/views/error_view.ex",
     "lib/library_web/views/page_view.ex",
     "lib/library/application.ex",
-    "lib/library_web/endpoint.ex",
-    "lib/library_web/controllers/plugs/require_auth.ex"
+    "lib/library_web/endpoint.ex"
   ]
 }

--- a/lib/library_web/controllers/page_controller.ex
+++ b/lib/library_web/controllers/page_controller.ex
@@ -3,6 +3,8 @@ defmodule LibraryWeb.PageController do
   import Library.Books
   alias Library.GoogleBooks
 
+  plug LibraryWeb.Plugs.RequireAuth when action in [:checkout, :checkin]
+
   def index(conn, _params) do
     books = list_books()
 

--- a/test/library_web/controllers/page_controller_test.exs
+++ b/test/library_web/controllers/page_controller_test.exs
@@ -59,6 +59,14 @@ defmodule LibraryWeb.PageControllerTest do
     assert html_response(conn, 302) =~ "redirected"
   end
 
+  test "GET /checkout/:id fails with no user on the connection", %{conn: conn} do
+    %{id: id} = Books.create_book!(%{title: "some title", author_list: ["some author"]})
+
+    conn = conn
+    |> get("/checkout/#{id}")
+    assert html_response(conn, 302) =~ "redirected"
+  end
+
   test "GET /checkout/:id checks in a book", %{conn: conn} do
     %{id: id} = Books.create_book!(%{title: "some title", author_list: ["some author"]})
 


### PR DESCRIPTION
Adds the requirement for auth to checkin/checkout routes. The links only showed up when a user was logged in before, but now non logged in users won't be able to access even if they type the url in.

#43